### PR TITLE
Remove catalog name from app_list

### DIFF
--- a/ciclic
+++ b/ciclic
@@ -87,7 +87,7 @@ def app_list(all=False, domain=DOMAIN):
     )
 
     for i in response.json():
-        print(f"{i['name']} ({i['app_list']}) - {i['url']}")
+        print(f"{i['name']} - {i['url']}")
 
 
 def delete(job_id, domain=DOMAIN):


### PR DESCRIPTION
Idk I'm just bored of these names like `foobar (Apps) (unstable) (~arm~)`, I know that's because historically we had official vs. community but meh >_> 