### PR TITLE
Send SIGTERM when cancelling jobs ?

### DIFF
--- a/run.py
+++ b/run.py
@@ -440,6 +440,7 @@ async def run_job(worker, job):
             }, ["jobs", f"job-{job.id}", f"app-jobs-{job.url_or_path}"])
 
     except CancelledError:
+        command.terminate()
         job.log += "\n"
         job.end_time = datetime.now()
         job.state = "canceled"


### PR DESCRIPTION
ihavenoideawhatimdoing.jpg, but that makes the lock management easier (otherwise the existing process keeps running etc)

I'm assuming the CancelledError is what's triggered when somebody cancels the job from the webui