### PR TITLE
Trigger job via GitHub comments

### DIFF
--- a/run.py
+++ b/run.py
@@ -882,6 +882,34 @@ async def api_restart_job(request, job_id):
     return response.text("ok")
 
 
+# Meant to interface with https://shields.io/endpoint
+@app.route("/api/job/<job_id:int>/badge", methods=['GET'])
+async def api_badge_job(request, job_id):
+
+    job = Job.select().where(Job.id == job_id)
+
+    if job.count() == 0:
+        raise NotFound(f"Error: no job with the id '{job_id}'")
+
+    job = job[0]
+
+    state_to_color = {
+        'scheduled': 'lightgrey',
+        'runnning': 'blue',
+        'done': 'brightgreen',
+        'failure': 'red',
+        'error': 'red',
+        'canceled': 'yellow',
+    }
+
+    return response.json({
+        "schemaVersion": 1,
+        "label": "tests",
+        "message": job.state,
+        "color": state_to_color[job.state]
+    })
+
+
 @app.route('/job/<job_id>')
 @jinja.template('job.html')
 async def html_job(request, job_id):

--- a/run.py
+++ b/run.py
@@ -989,7 +989,8 @@ async def github(request):
     # - On issue/PRs which are still open
     if hook_type != "issue_comment" \
       or hook_infos["action"] != "created" \
-      or hook_infos["issue"]["state"] != "open": \
+      or hook_infos["issue"]["state"] != "open" \
+      or "pull_request" not in hook_infos["issue"]:
         # idk what code we want to return
         abort(400)
 


### PR DESCRIPTION
![](https://i.imgflip.com/4tlnxx.jpg)

Tested here https://github.com/YunoHost-Apps/helloworld_ynh/pull/1 and http://ci-apps-dev-v2beta1.nohost.me/

Basically you say `!testme` in a PR comment and that'll trigger a test on the CI. This will only be accepted if you're flagged as member/owner of the repo/organization in Github. The big plus is that this should require very loose maintenance / configuration in every day life : 
- the webhook configuration is global to Yunohost-Apps
- no need anymore to ask people an SSH key to get access to the dev CI
- no need anymore to run a weird bash script with rsync magic then wait 5 minutes for the cron job to pickup your job (though now you kinda must create a branch+PR to be able to trigger the job though)

Still planning to build on this such that the CI uses the yunobot account to answer with a comment with a cool jenkins-like badge displaying the job status + link to the created job

Also probably more polishing to better handle exceptions :s 