### PR TITLE
Make config.py relative

### DIFF
--- a/run.py
+++ b/run.py
@@ -1117,7 +1117,7 @@ def format_frame(f):
     return dict([(k, str(getattr(f, k))) for k in keys])
 
 
-def main(config="/var/www/yunorunner/config.py"):
+def main(config="./config.py"):
 
     default_config = {
         "BASE_URL": "",


### PR DESCRIPTION
Yunorunner multi install fail cause of `config.py` being hard coded
cf [https://ci-apps-dev.yunohost.org/ci/job/598](https://ci-apps-dev.yunohost.org/ci/job/598)