### PR TITLE
handle multi worker

### DIFF
--- a/run.py
+++ b/run.py
@@ -89,7 +89,7 @@ def datetime_to_epoch_json_converter(o):
 
 # define a custom json dumps to convert datetime
 def my_json_dumps(o):
-    json.dumps(o, default=datetime_to_epoch_json_converter)
+    return json.dumps(o, default=datetime_to_epoch_json_converter)
 
 
 task_logger = logging.getLogger("task")


### PR DESCRIPTION
Linked with: https://github.com/YunoHost/CI_package_check/pull/38 & https://github.com/YunoHost/package_check/pull/113

Example here with 2 of my scaleway:
https://ci1.kayou.io
https://ci2.kayou.io

ci1 is the "master" where I ran the install script of CI_package_check, and I configured the lxd cluster, i also open the port 8443 which is used by other server on this cluster
(
to create a bridge interface when we use the cluster feature:
```bash
lxc network create lxdbr0 --target ciX.kayou.io # do this for each server
lxc network create lxdbr0 ipv4.address=192.168.X.1/24
lxc network set lxdbr0 ipv4.nat=true
lxc network attach-profile lxdbr0 default
```
)
ci2 is the "slave", where I just join the cluster.

You can see the result here: https://ci1.kayou.io/ci/

If anyone want access on those server, ping me, I'd be happy to give them to you.

Right now, there is 4 workers (2 per server), when I do a `lxc list` i have:
```
+--------------------------------------+---------+------------------------+-----------------------------------------------+-----------+-----------+--------------+
|                 NAME                 |  STATE  |          IPV4          |                     IPV6                      |   TYPE    | SNAPSHOTS |   LOCATION   |
+--------------------------------------+---------+------------------------+-----------------------------------------------+-----------+-----------+--------------+
| ynh-appci-buster-amd64-stable-test-1 | RUNNING | 192.168.100.106 (eth0) | fd42:6bab:5e9a:5d39:216:3eff:fe2b:bef7 (eth0) | CONTAINER | 0         | ci2.kayou.io |
+--------------------------------------+---------+------------------------+-----------------------------------------------+-----------+-----------+--------------+
| ynh-appci-buster-amd64-stable-test-2 | RUNNING | 192.168.100.142 (eth0) | fd42:6bab:5e9a:5d39:216:3eff:feef:bf84 (eth0) | CONTAINER | 1         | ci1.kayou.io |
+--------------------------------------+---------+------------------------+-----------------------------------------------+-----------+-----------+--------------+
| ynh-appci-buster-amd64-stable-test-3 | RUNNING | 192.168.100.219 (eth0) | fd42:6bab:5e9a:5d39:216:3eff:fe55:db08 (eth0) | CONTAINER | 2         | ci1.kayou.io |
+--------------------------------------+---------+------------------------+-----------------------------------------------+-----------+-----------+--------------+
| ynh-appci-buster-amd64-stable-test-4 | RUNNING | 192.168.100.254 (eth0) | fd42:6bab:5e9a:5d39:216:3eff:fe56:578f (eth0) | CONTAINER | 2         | ci2.kayou.io |
+--------------------------------------+---------+------------------------+-----------------------------------------------+-----------+-----------+--------------+
```

~~There is an issue with the current package_check code. The `curl` command to validate if we have access to the app fails when the container is on another server because the ip of containers in ci2 is not accessible on ci1 (ofc). I think this problem can be solved in several ways:~~
- ~~Don't use clustering, and use only local workers~~
- ~~Do the curl with ssh~~
- ~~Do the curl on the public ip of the servers (ci1 or ci2) and redirect the trafic to the containers~~
- ~~Make the container having a public ip~~
- ~~...~~
Fixed by: https://github.com/YunoHost/package_check/pull/113/commits/9f6cc8dceb4096040ec581e972c8db878c111286