### PR TITLE
Clear end time when starting to run job

### DIFF
--- a/run.py
+++ b/run.py
@@ -412,6 +412,7 @@ async def jobs_dispatcher():
 
             job.state = "running"
             job.started_time = datetime.now()
+            job.end_time = None
             job.save()
 
             worker.state = "busy"


### PR DESCRIPTION
Fixes #32. This should clear the end time with a job is dispatched to be run.