### PR TITLE
Make ciclic read config.py to retrieve PORT

### DIFF
--- a/ciclic
+++ b/ciclic
@@ -7,8 +7,12 @@ import requests
 
 from argh.decorators import named
 
+try:
+    from config import *
+except ImportError:
+    PORT="4242"
 
-DOMAIN = "localhost:4242"
+DOMAIN = "localhost:" + str(PORT)
 
 def require_token():
     if os.path.exists("token") and open("token").read().strip():


### PR DESCRIPTION
Any yunorunner update would break `ciclic`'s config. Let's have it retrieve the `PORT` automatically.