### PR TITLE
Have a specific title for the job page

### DIFF
--- a/templates/job.html
+++ b/templates/job.html
@@ -1,5 +1,7 @@
 <% extends "base.html" %>
 
+<% block title %>Job #{{job.id}} <% if app %>{ app.name }<% else %>{{ job.name }}<% endif %> | YunoRunner for CI<% endblock %>
+
 <% block content %>
 <section class="section" id="job">
     <div class="container" v-bind:class="{deleted: job.deleted}">


### PR DESCRIPTION
(untested)

Have a specific title for the job page, since "YunoRunner for CI" is pretty unspecific, especially when opening multiple job tabs.

Possible extension: make the default title configurable to distinguish our multiple CI servers.