### PR TITLE
Store only lowercase urls and names in the DB

### DIFF
--- a/src/yunorunner/migrations/002_lowercase.py
+++ b/src/yunorunner/migrations/002_lowercase.py
@@ -1,0 +1,19 @@
+"""Replace"""
+
+import peewee as pw
+from peewee_migrate import Migrator
+
+
+def migrate(migrator: Migrator, database: pw.Database, *, fake: bool = False) -> None:
+    if fake:
+        return
+
+    migrator.sql("UPDATE repo SET name = lower(name)")
+    migrator.sql("UPDATE repo SET url = lower(url)")
+
+    migrator.sql("UPDATE job SET name = lower(name)")
+    migrator.sql("UPDATE job SET url_or_path = lower(url_or_path)")
+
+
+def rollback(migrator: Migrator, database: pw.Database, *, fake: bool = False) -> None:
+    """No rollback."""

--- a/src/yunorunner/models.py
+++ b/src/yunorunner/models.py
@@ -5,12 +5,17 @@ import peewee
 db = peewee.SqliteDatabase("db.sqlite")
 
 
+class LowercaseCharField(peewee.CharField):
+    def db_value(self, value: str) -> str:
+        return value.lower()
+
+
 class Repo(peewee.Model):
     if TYPE_CHECKING:
         id: int
 
-    name = peewee.CharField()  # TODO make this uniq/index
-    url = peewee.CharField()
+    name = LowercaseCharField()  # TODO make this uniq/index
+    url = LowercaseCharField()
     revision = peewee.CharField(null=True)
 
     state = peewee.CharField(
@@ -31,8 +36,8 @@ class Job(peewee.Model):
     if TYPE_CHECKING:
         id: int
 
-    name = peewee.CharField()
-    url_or_path = peewee.CharField()
+    name = LowercaseCharField()
+    url_or_path = LowercaseCharField()
 
     state = peewee.CharField(
         choices=(

--- a/src/yunorunner/run.py
+++ b/src/yunorunner/run.py
@@ -286,9 +286,9 @@ async def monitor_apps_lists(
                 # guess :/
                 # this isn't perfect because that could overwrite added by
                 # hand jobs but well...
-                url = repo.url.lower()
+
                 for job in Job.select().where(
-                    fn.LOWER(Job.url_or_path) == url, Job.state == "scheduled"
+                    Job.url_or_path == repo.url, Job.state == "scheduled"
                 ):
                     job.url_or_path = repo.url
                     job.save()
@@ -393,9 +393,8 @@ async def monitor_apps_lists(
             "start by removing its scheduled job if there are any...",
             repo_name,
         )
-        url = repo.url.lower()
         for job in Job.select().where(
-            fn.LOWER(Job.url_or_path) == url, Job.state == "scheduled"
+            Job.url_or_path == repo.url, Job.state == "scheduled"
         ):
             await stop_job(job.id)  # not sure this is going to work
             job_id = job.id
@@ -820,7 +819,7 @@ async def run_job(worker: Worker, job: Job) -> None:
 
             shutil.copy(full_log, RESULTS_DIR / "logs" / f"{job.id}.log")
             if "ci-apps-dev.yunohost.org" in app.config.BASE_URL:
-                job_app_branch = job.url_or_path.lower().strip("/").split("/")[-1]  # type: ignore
+                job_app_branch = job.url_or_path.strip("/").split("/")[-1]  # type: ignore
                 if "PR #" in job.name:  # type: ignore
                     pr_id = job.name.split("#")[-1].split(",")[0].strip(")")  # type: ignore
                     pr_url = job.url_or_path.rsplit("/", 2)[0] + "/pull/" + pr_id  # type: ignore
@@ -1258,10 +1257,9 @@ async def ws_app(request: Request, websocket: Websocket, app_name: str) -> None:
 
     subscribe(websocket, f"app-jobs-{_app.url}")
 
-    url = _app.url.lower()
     job = list(
         Job.select()
-        .where(fn.LOWER(Job.url_or_path) == url)
+        .where(Job.url_or_path == _app.url)
         .order_by(-Job.id)
         .limit(10)
         .dicts()


### PR DESCRIPTION
* Add a migration that fixes the db
* Remove redundant fn.LOWER
* models: create LowercaseCharField to ensure db stores lowercase values from now on

EDIT: Actually, this change might have unwanted impact (rename PR -> pr in the job title, change the git URL might break links to branches with uppercase letters).
The bug I wanted to fix (being able to recognize which app (`Repo`) is which job about) should be fixed by another change (add a DB column or a table reference, but it needs some changes as -dev CIs don't have Repo table filled)
